### PR TITLE
enabled runners to use the run_cmd option

### DIFF
--- a/runners/basic_runner.py
+++ b/runners/basic_runner.py
@@ -29,9 +29,13 @@ class BasicRunner(Task.Task):
 
         if self.test_inputs: tst_str = ' {test input: %s} ' % tst_str
 
-        return '%s: %s%s%s%s\n' % (
-            self.__class__.__name__.replace('_task', ''),
-            src_str, sep, tgt_str, tst_str)
+        
+        return '{name}: {source_str}{seperator}{target_str}{test_str}\n'.format(
+            name = self.__class__.__name__.replace('_task', ''),
+            source_str = self.format_command(src_str),
+            seperator = sep,
+            target_str = tgt_str,
+            test_str = tst_str)
 
 
     def runnable_status(self):
@@ -71,14 +75,13 @@ class BasicRunner(Task.Task):
         """
         bld = self.generator.bld
 
+        # split the command string into a list of strings
         cmd = self.format_command(self.inputs[0].abspath()).split(' ')
 
-        # If this is a benchmark run and we have specified
-        # an output file name; use it.
+        # If this is a benchmark and we need to retrieve the result file
         if  bld.has_tool_option('run_benchmark') \
         and bld.has_tool_option('python_result'):
-            cmd += ["--pyfile={}".format(
-                bld.get_tool_option("python_result"))]
+            cmd += ["--pyfile={}".format(bld.get_tool_option("python_result"))]
 
         # First check whether we require any test files
         for t in self.test_inputs:

--- a/runners/ssh_runner.py
+++ b/runners/ssh_runner.py
@@ -19,10 +19,7 @@ class SSHRunner(BasicRunner):
         ssh_user = bld.get_tool_option('ssh_user')
         ssh_target = ssh_user + '@' + ssh_host
 
-        # ssh command as a list
         ssh_cmd = ['ssh', ssh_target]
-
-        # scp command as a list
         scp_cmd = ['scp']
 
         # Enumerate the test files
@@ -40,20 +37,20 @@ class SSHRunner(BasicRunner):
             self.save_result(results)
             return
 
-        # To run the binary; cd to dest_dir, run the binary ...
-        run_binary_cmd = "cd {0};./{1}".format(dest_dir, binary)
+        run_binary_cmd = "./{1}".format(binary)
 
-        # Wait! is this a benchmark, and if so do we need to retrieve the
-        # result file?
+        # If this is a benchmark and we need to retrieve the result file
         if  bld.has_tool_option('run_benchmark') \
         and bld.has_tool_option('python_result'):
-            # ... add the benchmark python result output filename option ...
+            # Add the benchmark python result output filename option
             run_binary_cmd += " --pyfile={}".format(
                 bld.get_tool_option("python_result"))
 
-        # ... finally echo the exit code
-        result = run_cmd(ssh_cmd + \
-            ["{};echo shellexit:$?".format(run_binary_cmd)])
+        # Finally echo the exit code
+        result = run_cmd(
+            ssh_cmd + \
+            ["cd {0};{};echo shellexit:$?".format(dest_dir, run_binary_cmd)])
+
         results.append(result)
 
         if result['return_code'] != 0:


### PR DESCRIPTION
Hi @mortenvp, @petya2164. I've re-enabled the run_cmd option for the external runners. This way modifications of the the command to be run is easy-peasy. This way users are able to add special command line arguments to, e.g., benchmarks, run by the runners.

I'm just gonna merge the pull request pretty fast, as I can only test whether it works on all the slaves by having the changes in the master. :/
