### PR TITLE
xrange -> range

### DIFF
--- a/runners/basic_runner.py
+++ b/runners/basic_runner.py
@@ -92,7 +92,7 @@ class BasicRunner(Task.Task):
             # Split the arguments BEFORE substituting the executable path
             args = testcmd.split(' ')
             # Substitute the path to the relevant element
-            for i in xrange(len(args)):
+            for i in range(len(args)):
                 if '%s' in args[i]:
                     args[i] = args[i] % executable
                     break


### PR DESCRIPTION
To support both python 2.x and 3.x we need to use range instead of xrange.
