### PR TITLE
Use -Os flag on iOS + Simplify sanitizers mkspecs with force_debug parameter

### DIFF
--- a/mkspec/clang_common.py
+++ b/mkspec/clang_common.py
@@ -12,11 +12,13 @@ from os.path import abspath, expanduser
 import cxx_common
 
 @conf
-def mkspec_clang_configure(conf, major, minor, minimum = False):
+def mkspec_clang_configure(conf, major, minor, minimum = False,
+                           force_debug = False):
     """
-    :param major:   The major version number of the compiler, e.g. 3
-    :param minor:   The minor version number of the compiler, e.g. 3
-    :param minimum: Only check for a minimum compiler version, if true
+    :param major:       The major version number of the compiler, e.g. 3
+    :param minor:       The minor version number of the compiler, e.g. 4
+    :param minimum:     Only check for a minimum compiler version, if true
+    :param force_debug: Always compile with debugging flags, if true
     """
     # Where to look
     paths = conf.mkspec_get_toolchain_paths()
@@ -66,9 +68,9 @@ def mkspec_clang_configure(conf, major, minor, minimum = False):
     conf.link_add_flags()
 
     # Add our own cxx flags
-    conf.mkspec_set_clang_cxxflags()
+    conf.mkspec_set_clang_cxxflags(force_debug)
     # Add our own cc flags
-    conf.mkspec_set_clang_ccflags()
+    conf.mkspec_set_clang_ccflags(force_debug)
 
 @conf
 def mkspec_clang_android_configure(conf, major, minor):
@@ -83,19 +85,27 @@ def mkspec_clang_ios_configure(conf, major, minor, min_ios_version, cpu):
     conf.mkspec_set_ios_options(min_ios_version, cpu)
 
 @conf
-def mkspec_set_clang_ccflags(conf):
+def mkspec_set_clang_ccflags(conf, force_debug = False):
 
-    conf.env['CFLAGS'] += ['-O2', '-Wextra', '-Wall']
+    optflag = '-O2'
+    # Use -Os (optimize for size) flag on iOS, because -O2 produces unstable
+    # code on this platform
+    if conf.get_mkspec_platform() == 'ios': optflag = '-Os'
+    conf.env['CFLAGS'] += [optflag, '-Wextra', '-Wall']
 
-    if conf.has_tool_option('cxx_debug'):
+    if conf.has_tool_option('cxx_debug') or force_debug:
         conf.env['CFLAGS'] += ['-g']
 
 @conf
-def mkspec_set_clang_cxxflags(conf):
+def mkspec_set_clang_cxxflags(conf, force_debug = False):
 
-    conf.env['CXXFLAGS'] += ['-O2', '-Wextra', '-Wall']
+    optflag = '-O2'
+    # Use -Os (optimize for size) flag on iOS, because -O2 produces unstable
+    # code on this platform
+    if conf.get_mkspec_platform() == 'ios': optflag = '-Os'
+    conf.env['CXXFLAGS'] += [optflag, '-Wextra', '-Wall']
 
-    if conf.has_tool_option('cxx_debug'):
+    if conf.has_tool_option('cxx_debug') or force_debug:
         conf.env['CXXFLAGS'] += ['-g']
     elif not conf.get_mkspec_platform() in ['mac', 'ios']:
         conf.env['LINKFLAGS'] += ['-s']

--- a/mkspec/clang_mkspecs.py
+++ b/mkspec/clang_mkspecs.py
@@ -168,14 +168,8 @@ def cxx_clang34_address_sanitizer_x86(conf):
     http://clang.llvm.org/docs/AddressSanitizer.html
     """
 
-    conf.mkspec_clang_configure(3,4)
+    conf.mkspec_clang_configure(3, 4, force_debug=True)
     conf.mkspec_add_common_flag('-m32')
-
-    if not conf.has_tool_option('cxx_debug'):
-        conf.mkspec_add_common_flag('-g')
-
-    if '-s' in conf.env['LINKFLAGS']:
-        conf.env['LINKFLAGS'].remove('-s')
 
     conf.mkspec_add_common_flag('-fsanitize=address')
     conf.mkspec_add_common_flag('-fno-omit-frame-pointer')
@@ -195,14 +189,8 @@ def cxx_clang34_address_sanitizer_x64(conf):
     http://clang.llvm.org/docs/AddressSanitizer.html
     """
 
-    conf.mkspec_clang_configure(3,4)
+    conf.mkspec_clang_configure(3, 4, force_debug=True)
     conf.mkspec_add_common_flag('-m64')
-
-    if not conf.has_tool_option('cxx_debug'):
-        conf.mkspec_add_common_flag('-g')
-
-    if '-s' in conf.env['LINKFLAGS']:
-        conf.env['LINKFLAGS'].remove('-s')
 
     conf.mkspec_add_common_flag('-fsanitize=address')
     conf.mkspec_add_common_flag('-fno-omit-frame-pointer')
@@ -223,14 +211,8 @@ def cxx_clang34_memory_sanitizer_x86(conf):
     http://clang.llvm.org/docs/MemorySanitizer.html
     """
 
-    conf.mkspec_clang_configure(3,4)
+    conf.mkspec_clang_configure(3, 4, force_debug=True)
     conf.mkspec_add_common_flag('-m32')
-
-    if not conf.has_tool_option('cxx_debug'):
-        conf.mkspec_add_common_flag('-g')
-
-    if '-s' in conf.env['LINKFLAGS']:
-        conf.env['LINKFLAGS'].remove('-s')
 
     conf.mkspec_add_common_flag('-fsanitize=memory')
     conf.mkspec_add_common_flag('-fsanitize-memory-track-origins')
@@ -252,14 +234,8 @@ def cxx_clang34_memory_sanitizer_x64(conf):
     http://clang.llvm.org/docs/MemorySanitizer.html
     """
 
-    conf.mkspec_clang_configure(3,4)
+    conf.mkspec_clang_configure(3, 4, force_debug=True)
     conf.mkspec_add_common_flag('-m64')
-
-    if not conf.has_tool_option('cxx_debug'):
-        conf.mkspec_add_common_flag('-g')
-
-    if '-s' in conf.env['LINKFLAGS']:
-        conf.env['LINKFLAGS'].remove('-s')
 
     conf.mkspec_add_common_flag('-fsanitize=memory')
     conf.mkspec_add_common_flag('-fsanitize-memory-track-origins')
@@ -275,14 +251,8 @@ def cxx_clang34_thread_sanitizer_x86(conf):
     """
     http://clang.llvm.org/docs/ThreadSanitizer.html
     """
-    conf.mkspec_clang_configure(3,4)
+    conf.mkspec_clang_configure(3, 4, force_debug=True)
     conf.mkspec_add_common_flag('-m32')
-
-    if not conf.has_tool_option('cxx_debug'):
-        conf.mkspec_add_common_flag('-g')
-
-    if '-s' in conf.env['LINKFLAGS']:
-        conf.env['LINKFLAGS'].remove('-s')
 
     conf.mkspec_add_common_flag('-fsanitize=thread')
 
@@ -295,13 +265,7 @@ def cxx_clang34_thread_sanitizer_x64(conf):
     """
     http://clang.llvm.org/docs/ThreadSanitizer.html
     """
-    conf.mkspec_clang_configure(3,4)
+    conf.mkspec_clang_configure(3, 4, force_debug=True)
     conf.mkspec_add_common_flag('-m64')
-
-    if not conf.has_tool_option('cxx_debug'):
-        conf.mkspec_add_common_flag('-g')
-
-    if '-s' in conf.env['LINKFLAGS']:
-        conf.env['LINKFLAGS'].remove('-s')
 
     conf.mkspec_add_common_flag('-fsanitize=thread')


### PR DESCRIPTION
@jpihl -Os is the antidote for the iOS segfault. -O2 produces unstable code apparently :(
