### PR TITLE
fix test file bug in basic runner

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -6,8 +6,8 @@ of every change, see the Git log.
 
 Latest
 ------
-* tbd
-
+* Bugfix: Test files are now allowed to be in the source directory when using
+          the BasicRunner.
 
 2.33.0
 ------

--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
 external-waf-tools
 ==================
 
-Repository for managing the Waf tools used by Steinwurf 
+Repository for managing the Waf tools used by Steinwurf

--- a/runners/basic_runner.py
+++ b/runners/basic_runner.py
@@ -125,9 +125,7 @@ class BasicRunner(Task.Task):
         # First check whether we require any test files
         for t in self.test_inputs:
 
-            filename = os.path.basename(t.abspath())
-
-            test_file_out = self.inputs[0].parent.find_or_declare(filename)
+            test_file_out = self.inputs[0].parent.get_bld().make_node([t.name])
 
             Logs.debug("wr: test file {0} -> {1}".format(
                 t.abspath(), test_file_out.abspath()))


### PR DESCRIPTION
@mortenvp @petya2164, do you see any issues with this?

The issue is that i want test files to be in the `project_repo/test` directory, instead of the root of the repository.
But since `find_or_declare` (https://waf.googlecode.com/svn/docs/apidocs/Node.html#waflib.Node.Node.find_or_declare) only creates the file if it's not already in the build or the source folder, the test file is not created.
