### PR TITLE
Restore default destdir + Rename wurf_default_dest_dir.py to wurf_default_prefix.py

### DIFF
--- a/NEWS.rst
+++ b/NEWS.rst
@@ -7,6 +7,8 @@ of every change, see the Git log.
 Latest
 ------
 * tbd
+* Patch: Restore the original ``--destdir`` option, since overriding its
+  default value break our ``--install_path`` option and related functionality.
 
 4.25.0
 ------

--- a/NEWS.rst
+++ b/NEWS.rst
@@ -8,7 +8,7 @@ Latest
 ------
 * tbd
 * Patch: Restore the original ``--destdir`` option, since overriding its
-  default value break our ``--install_path`` option and related functionality.
+  default value breaks our ``--install_path`` option and related functionality.
 
 4.25.0
 ------

--- a/wscript
+++ b/wscript
@@ -11,7 +11,7 @@ import wurf_project_generator
 import wurf_android_soname
 import wurf_copy_binary
 import wurf_limit_includes
-import wurf_default_dest_dir
+import wurf_default_prefix
 
 from waflib import Options
 from waflib.Configure import conf
@@ -64,7 +64,7 @@ def options(opt):
     opt.load('wurf_install_path')
     opt.load('wurf_cxx_mkspec')
     opt.load('wurf_runner')
-    opt.load('wurf_default_dest_dir')
+    opt.load('wurf_default_prefix')
 
 
 def configure(conf):

--- a/wurf_default_prefix.py
+++ b/wurf_default_prefix.py
@@ -12,51 +12,40 @@ developers that need easy access to the .so, .a and includes.
 
 
 def options(opt):
-    group = opt.option_groups['Configuration options']
-    group.remove_option('--destdir')
-
-    project_dir = opt.srcnode.abspath()
-
-    group.add_option('--destdir',
-                     help='installation root [default: %r]' % project_dir,
-                     default=project_dir, dest='destdir')
 
     # Determine the default prefix. We would like to avoid installing
-    # "incompatiple" versions of the libraries into the same folders.
+    # "incompatible" versions of the libraries into the same folders.
     #
-    # To acheive this goal we have choosen the following strategy.
+    # To achieve this goal, we have choosen the following strategy:
     #
     # 1. If we are in a git repository use the following:
     #    a. If on a tag (released version) use the version number
     #    b. Otherwise use the SHA1
-    # 2. If not in a git repository we use the postfix "_install".
+    # 2. If not in a git repository, we use the postfix "_install".
     #
     # To do the above we require a recent version of our Waf build tool.
-    #
-    # If this is not available we fallback to option 2.
+    # If this is not available we fallback to "_install".
 
-    registry = getattr(opt, 'registry', None)
+    version = "install"
+    project_dir = opt.srcnode.abspath()
 
-    if registry:
-
+    # These operations might fail if our waf API changes in some way
+    try:
         git = opt.registry.require('git')
 
         if git.is_git_repository(cwd=project_dir):
-
             version = git.current_tag(cwd=project_dir)
 
             if not version:
-                # Take the current commit and limit it to the first X characters
+                # Use the first 8 characters of the current commit
                 version = git.current_commit(cwd=project_dir)[:8]
 
-        else:
-            version = "install"
-
-    else:
-        version = "install"
+    except Exception:
+        pass
 
     appname = getattr(waflib.Context.g_module, 'APPNAME')
 
+    group = opt.option_groups['Configuration options']
     group.remove_option('--prefix')
     default_prefix = os.path.join(os.sep, appname + '_' + version)
     group.add_option('--prefix', dest='prefix', default=default_prefix,


### PR DESCRIPTION
@mortenvp Please take a look when you have some time. I think this is a conservative solution to fix the problem that we created with overriding the default destdir.