### PR TITLE
fix regex warnings

### DIFF
--- a/project_generators/msvs.py
+++ b/project_generators/msvs.py
@@ -359,7 +359,7 @@ def compile_template(line):
     return Task.funex(fun)
 
 
-re_blank = re.compile("(\n|\r|\\s)*\n", re.M)
+re_blank = re.compile(r"(\n|\r|\s)*\n", re.M)
 
 
 def rm_blank_lines(txt):
@@ -398,7 +398,7 @@ def stealth_write(self, data, flags="wb"):
 
 Node.Node.stealth_write = stealth_write
 
-re_quote = re.compile("[^a-zA-Z0-9-]")
+re_quote = re.compile(r"[^a-zA-Z0-9-]")
 
 
 def quote(s):

--- a/runners/android_runner.py
+++ b/runners/android_runner.py
@@ -77,7 +77,7 @@ class AndroidRunner(BasicRunner):
 
         # Almost done. Look for the exit code in the output
         # and fail if non-zero
-        match = re.search("shellexit:(\d+)", result["stdout"])
+        match = re.search(r"shellexit:(\d+)", result["stdout"])
 
         if not match:
             error_msg = "Failed to find return code in output!\n"

--- a/runners/ssh_runner.py
+++ b/runners/ssh_runner.py
@@ -261,7 +261,7 @@ class SSHRunner(BasicRunner):
 
         # Almost done. Look for the exit code in the output
         # and fail if non-zero
-        match = re.search("shellexit:(\d+)", result["stdout"])
+        match = re.search(r"shellexit:(\d+)", result["stdout"])
 
         if not match:
             error_msg = "Failed to find return code in output!\n"


### PR DESCRIPTION
Fixes multiple on load syntax warnings around regex strings not being properly escaped.

```
Load "waf-tools" (load)                  : 5.4.0      (resolve_symlinks/waf-tools => resolved_dependencies/waf-tools-ae40a5/6379b83992) 
/.../waf-tools/runners/android_runner.py:80: SyntaxWarning: invalid escape sequence '\d'
  match = re.search("shellexit:(\d+)", result["stdout"])
/.../resolve_symlinks/waf-tools/runners/ssh_runner.py:264: SyntaxWarning: invalid escape sequence '\d'
  match = re.search("shellexit:(\d+)", result["stdout"])